### PR TITLE
Fixes Registry URL

### DIFF
--- a/.github/workflows/frontend-staging.yml
+++ b/.github/workflows/frontend-staging.yml
@@ -16,6 +16,11 @@ jobs:
         uses: mikefarah/yq@v4.11.2
         with:
           cmd: yq eval '.ui-components[0].folder' 'vtex.yml'
+      - name: Get vendor
+        id: getVendor
+        uses: mikefarah/yq@v4.11.2
+        with:
+          cmd: yq eval '.vendor' 'vtex.yml'
       - name: Export env.WORK_DIR as the frontend path
         run: echo "WORK_DIR=${{ steps.getFrontendFolder.outputs.result }}" >> $GITHUB_ENV
       - run: yarn install
@@ -23,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
-          registry-url: 'https://sangalli.jfrog.io/artifactory/api/npm/default-npm-virtual/'
+          registry-url: `https://vtexapps.jfrog.io/artifactory/api/npm/${{ steps.getVendor.outputs.result }}-npm-local/`
           # Defaults to the user or organization that owns the workflow file
       - run: yarn publish
         working-directory: ${{ env.WORK_DIR }}

--- a/.github/workflows/frontend-staging.yml
+++ b/.github/workflows/frontend-staging.yml
@@ -24,11 +24,14 @@ jobs:
       - name: Export env.WORK_DIR as the frontend path
         run: echo "WORK_DIR=${{ steps.getFrontendFolder.outputs.result }}" >> $GITHUB_ENV
       - run: yarn install
-        working-directory: ${{ env.WORK_DIR }}
+        working-directory:
+      - name: Set Registry URL to env
+        id: setRegistryUrl
+        run: echo "REGISTY_URL=https://vtexapps.jfrog.io/artifactory/api/npm/${{ steps.getVendor.outputs.result }}-npm-local/" >> $GITHUB_ENV
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
-          registry-url: `https://vtexapps.jfrog.io/artifactory/api/npm/${{ steps.getVendor.outputs.result }}-npm-local/`
+          registry-url:  ${{ env.REGISTRY_URL }}
           # Defaults to the user or organization that owns the workflow file
       - run: yarn publish
         working-directory: ${{ env.WORK_DIR }}


### PR DESCRIPTION
Fixes this [Bug](https://vtex-dev.atlassian.net/browse/CCAS-408)

* Uses `vtexapps` Artifactory
* Uses correct (according to vendor) npm registry


Example of it running: 
https://github.com/vwraposo/test-session/runs/5155249978?check_suite_focus=true

The publish failed due to some other issue already mapped.  But in. the image you can see that the env var for the registry url was set correctly.

![Screen Shot 2022-02-11 at 8 29 51 AM](https://user-images.githubusercontent.com/12701600/153584288-92bab7c4-38d9-4326-83d0-10915051f92e.png)

